### PR TITLE
2.3.1 - Add option FNM_NOESCAPE for pattern matching

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,53 +1,53 @@
 {
-  "name": "mediact/data-container",
-  "type": "library",
-  "description": "Data container library",
-  "license": "MIT",
-  "authors": [
-    {
-      "name": "Mediact",
-      "email": "contact@mediact.nl"
+    "name": "mediact/data-container",
+    "type": "library",
+    "description": "Data container library",
+    "license": "MIT",
+    "authors": [
+        {
+            "name": "Mediact",
+            "email": "contact@mediact.nl"
+        },
+        {
+            "name": "Jan-Marten de Boer",
+            "role": "developer"
+        }
+    ],
+    "minimum-stability": "stable",
+    "prefer-stable": true,
+    "require": {
+        "php": "^7.0"
     },
-    {
-      "name": "Jan-Marten de Boer",
-      "role": "developer"
+    "require-dev": {
+        "phpunit/phpunit": "@stable",
+        "kint-php/kint": "@stable",
+        "mediact/testing-suite": "@stable"
+    },
+    "autoload": {
+        "psr-4": {
+            "Mediact\\DataContainer\\": "src/"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "Mediact\\DataContainer\\Tests\\": "tests/"
+        }
+    },
+    "archive": {
+        "exclude": [
+            "/bitbucket-pipelines.yml",
+            "/.gitignore",
+            "/phpunit.xml",
+            "/phpmd.xml",
+            "/phpcs.xml",
+            "/phpstan.neon",
+            "/tests",
+            "/example"
+        ]
+    },
+    "extra": {
+        "grumphp": {
+            "config-default-path": "vendor/mediact/testing-suite/config/default/grumphp.yml"
+        }
     }
-  ],
-  "minimum-stability": "stable",
-  "prefer-stable": true,
-  "require": {
-    "php": "^7.0"
-  },
-  "require-dev": {
-    "phpunit/phpunit": "@stable",
-    "kint-php/kint": "@stable",
-    "mediact/testing-suite": "@stable"
-  },
-  "autoload": {
-    "psr-4": {
-      "Mediact\\DataContainer\\": "src/"
-    }
-  },
-  "autoload-dev": {
-    "psr-4": {
-      "Mediact\\DataContainer\\Tests\\": "tests/"
-    }
-  },
-  "archive": {
-    "exclude": [
-      "bitbucket-pipelines.yml",
-      ".gitignore",
-      "phpunit.xml",
-      "phpmd.xml",
-      "phpcs.xml",
-      "phpstan.neon",
-      "tests",
-      "example"
-    ]
-  },
-  "extra": {
-    "grumphp": {
-      "config-default-path": "vendor/mediact/testing-suite/config/default/grumphp.yml"
-    }
-  }
 }

--- a/src/DataContainer.php
+++ b/src/DataContainer.php
@@ -278,7 +278,7 @@ class DataContainer implements DataContainerInterface
         $matchingKeys = array_filter(
             array_keys($data),
             function ($key) use ($pattern) {
-                return fnmatch($pattern, $key);
+                return fnmatch($pattern, $key, FNM_NOESCAPE);
             }
         );
 

--- a/tests/DataContainerTest.php
+++ b/tests/DataContainerTest.php
@@ -350,6 +350,18 @@ class DataContainerTest extends TestCase
                 $this->valuesProvider(),
                 'quux.*',
                 ['quux.0', 'quux.1', 'quux.2']
+            ],
+            // Assert glob does not escape paths.
+            [
+                [
+                    'models' => [
+                        'Foo\Bar\Baz' => [
+                            'qux' => 'quux'
+                        ]
+                    ]
+                ],
+                '*.Foo\Bar\*',
+                ['models.Foo\Bar\Baz']
             ]
         ];
     }


### PR DESCRIPTION
Paths that use backslashes in them, were incorrectly matched, because
`fnmatch` would escape them. By adding the option `FNM_NOESCAPE`, paths
containing namespaces are correctly resolved. E.g.:

`models.Acme\Library\Book.properties`