### PR TITLE
2.4.0 - Add data container filter and filter chain

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,3 +225,35 @@ class FooTraversableDataContainer implements DataContainerInterface, IteratorAgg
     }
 }
 ```
+
+## Filtering a container
+
+To filter a container, an implementation of `DataContainerFilterInterface` is
+required.
+
+A default implementation, used for chaining, is available.
+
+```php
+<?php
+use Mediact\DataContainer\DataContainerFilterInterface;
+use Mediact\DataContainer\DataContainerFilterChain;
+use Mediact\DataContainer\DataContainerInterface;
+
+/**
+ * @var DataContainerFilterInterface $fooFilter
+ * @var DataContainerFilterInterface $barFilter
+ * @var DataContainerFilterInterface $bazFilter
+ * @var DataContainerInterface       $container
+ */
+
+$filter = new DataContainerFilterChain(
+    $fooFilter,
+    $barFilter,
+    $bazFilter
+);
+
+if ($filter($container)) {
+    // Proceed.
+    $container->move('foo', 'bar');
+}
+```

--- a/src/DataContainerFilterChain.php
+++ b/src/DataContainerFilterChain.php
@@ -1,0 +1,46 @@
+<?php
+/**
+ * Copyright MediaCT. All rights reserved.
+ * https://www.mediact.nl
+ */
+
+namespace Mediact\DataContainer;
+
+class DataContainerFilterChain implements DataContainerFilterInterface
+{
+    /** @var DataContainerFilterInterface[] */
+    private $filters;
+
+    /**
+     * Constructor.
+     *
+     * @param DataContainerFilterInterface[] ...$filters
+     */
+    public function __construct(DataContainerFilterInterface ...$filters)
+    {
+        $this->filters = $filters;
+    }
+
+    /**
+     * Filter the given container.
+     *
+     * @param DataContainerInterface $container
+     *
+     * @return bool
+     */
+    public function __invoke(DataContainerInterface $container): bool
+    {
+        return array_reduce(
+            $this->filters,
+            function (
+                bool $carry,
+                DataContainerFilterInterface $filter
+            ) use (
+                $container
+            ) : bool {
+                return $carry && $filter($container);
+            },
+            true
+        );
+    }
+}

--- a/src/DataContainerFilterInterface.php
+++ b/src/DataContainerFilterInterface.php
@@ -1,0 +1,19 @@
+<?php
+/**
+ * Copyright MediaCT. All rights reserved.
+ * https://www.mediact.nl
+ */
+
+namespace Mediact\DataContainer;
+
+interface DataContainerFilterInterface
+{
+    /**
+     * Filter the given container.
+     *
+     * @param DataContainerInterface $container
+     *
+     * @return bool
+     */
+    public function __invoke(DataContainerInterface $container): bool;
+}

--- a/tests/DataContainerFilterChainTest.php
+++ b/tests/DataContainerFilterChainTest.php
@@ -1,0 +1,119 @@
+<?php
+/**
+ * Copyright MediaCT. All rights reserved.
+ * https://www.mediact.nl
+ */
+
+namespace Mediact\DataContainer\Tests;
+
+use Mediact\DataContainer\DataContainerFilterInterface;
+use Mediact\DataContainer\DataContainerInterface;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Mediact\DataContainer\DataContainerFilterChain;
+
+/**
+ * @coversDefaultClass \Mediact\DataContainer\DataContainerFilterChain
+ */
+class DataContainerFilterChainTest extends TestCase
+{
+    /**
+     * @dataProvider filterProvider
+     *
+     * @param bool                           $expected
+     * @param DataContainerFilterInterface[] ...$filters
+     *
+     * @return void
+     *
+     * @covers ::__construct
+     * @covers ::__invoke
+     */
+    public function testFilter(bool $expected, DataContainerFilterInterface ...$filters): void
+    {
+        $chain = new DataContainerFilterChain(...$filters);
+
+        $this->assertInstanceOf(DataContainerFilterChain::class, $chain);
+
+        $this->assertEquals(
+            $expected,
+            $chain(
+                $this->createMock(DataContainerInterface::class)
+            )
+        );
+    }
+
+    /**
+     * @return bool[][]|DataContainerFilterInterface[][]
+     */
+    public function filterProvider(): array
+    {
+        return [
+            [true],
+            [
+                true,
+                $this->createFilter(true)
+            ],
+            [
+                true,
+                $this->createFilter(true),
+                $this->createFilter(true),
+                $this->createFilter(true)
+            ],
+            [
+                false,
+                $this->createFilter(false)
+            ],
+            [
+                false,
+                $this->createFilter(true),
+                $this->createFilter(true),
+                $this->createFilter(false)
+            ],
+            [
+                false,
+                $this->createFilter(true),
+                $this->createFilter(false),
+                $this->createFilter(true)
+            ],
+            [
+                false,
+                $this->createFilter(false),
+                $this->createFilter(true),
+                $this->createFilter(true)
+            ],
+            [
+                false,
+                $this->createFilter(false),
+                $this->createFilter(false),
+                $this->createFilter(true)
+            ],
+            [
+                false,
+                $this->createFilter(false),
+                $this->createFilter(false),
+                $this->createFilter(false)
+            ]
+        ];
+    }
+
+    /**
+     * @param bool $accept
+     *
+     * @return DataContainerFilterInterface
+     */
+    private function createFilter(bool $accept): DataContainerFilterInterface
+    {
+        /** @var DataContainerFilterInterface|MockObject $filter */
+        $filter = $this->createMock(DataContainerFilterInterface::class);
+
+        $filter
+            ->expects(self::any())
+            ->method('__invoke')
+            ->with(
+                self::isInstanceOf(DataContainerInterface::class)
+            )
+            ->willReturn($accept);
+
+        return $filter;
+    }
+}


### PR DESCRIPTION
Add an interface for data container filters, to be able to filter data
containers based on their contents.

The filter is implemented by a filter chain, so as to be able to both
chain multiple filters, as well as have a default filter that always
returns true if left empty.