### PR TITLE
2.7.0 - Expand access to the root node

### DIFF
--- a/src/DataContainer.php
+++ b/src/DataContainer.php
@@ -83,10 +83,15 @@ class DataContainer implements IterableDataContainerInterface
      */
     public function set(string $path, $value = null)
     {
-        $keys        = $this->parsePath($path);
-        $last        = array_pop($keys);
-        $node        =& $this->getNodeReference($keys);
-        $node[$last] = $value;
+        $keys = $this->parsePath($path);
+        $last = array_pop($keys);
+        $node =& $this->getNodeReference($keys);
+
+        if (strlen($last) > 0) {
+            $node[$last] = $value;
+        } else {
+            $node = $value;
+        }
     }
 
     /**

--- a/src/DataContainer.php
+++ b/src/DataContainer.php
@@ -120,11 +120,13 @@ class DataContainer implements IterableDataContainerInterface
      */
     public function glob(string $pattern): array
     {
-        return $this->findArrayPathsByPatterns(
-            $this->data,
-            explode(static::SEPARATOR, $pattern),
-            ''
-        );
+        return $pattern === ''
+            ? [$pattern]
+            : $this->findArrayPathsByPatterns(
+                $this->data,
+                explode(static::SEPARATOR, $pattern),
+                ''
+            );
     }
 
     /**

--- a/tests/DataContainerTest.php
+++ b/tests/DataContainerTest.php
@@ -234,6 +234,12 @@ class DataContainerTest extends TestCase
                 'quux.quuux.foo',
                 'new_value',
                 $valuesD
+            ],
+            [
+                $this->valuesProvider(),
+                '',
+                ['foo' => 'bar'],
+                ['foo' => 'bar']
             ]
         ];
     }
@@ -362,6 +368,12 @@ class DataContainerTest extends TestCase
                 ],
                 '*.Foo\Bar\*',
                 ['models.Foo\Bar\Baz']
+            ],
+            // Assert glob returns the root path when required.
+            [
+                ['foo' => 'bar'],
+                '',
+                ['']
             ]
         ];
     }


### PR DESCRIPTION
This pull request adds functionality to expose the root node when the `glob` method is used and to update the root node when `set` is called with an empty path. This allows manipulation of the entire data set without the need to create a new instance of the data container.