### PR TITLE
2.7.1 Let data container interface be iterable

### DIFF
--- a/src/DataContainerDecoratorTrait.php
+++ b/src/DataContainerDecoratorTrait.php
@@ -6,6 +6,8 @@
 
 namespace Mediact\DataContainer;
 
+use Traversable;
+
 /**
  * Implements DataContainerInterface
  */
@@ -192,6 +194,17 @@ trait DataContainerDecoratorTrait
     {
         $this->getStorage()
             ->move($pattern, $replacement);
+    }
+
+    /**
+     * Retrieve an external iterator.
+     *
+     * @return Traversable
+     */
+    public function getIterator(): Traversable
+    {
+        return $this->getStorage()
+            ->getIterator();
     }
 
     /**

--- a/src/DataContainerInterface.php
+++ b/src/DataContainerInterface.php
@@ -6,10 +6,12 @@
 
 namespace Mediact\DataContainer;
 
+use IteratorAggregate;
+
 /**
  * Contains any data which can be accessed using dot-notation.
  */
-interface DataContainerInterface
+interface DataContainerInterface extends IteratorAggregate
 {
     /**
      * The separator used in paths.

--- a/src/DataContainerIteratorAggregateTrait.php
+++ b/src/DataContainerIteratorAggregateTrait.php
@@ -11,6 +11,8 @@ use Traversable;
 
 /**
  * Implements IteratorAggregate
+ *
+ * @deprecated IteratorAggregate is implemented by DataContainerDecoratorTrait.
  */
 trait DataContainerIteratorAggregateTrait
 {

--- a/src/IterableDataContainerInterface.php
+++ b/src/IterableDataContainerInterface.php
@@ -6,12 +6,13 @@
 
 namespace Mediact\DataContainer;
 
-use IteratorAggregate;
 use Traversable;
 
+/**
+ * @deprecated DataContainerInterface is iterable.
+ */
 interface IterableDataContainerInterface extends
-    DataContainerInterface,
-    IteratorAggregate
+    DataContainerInterface
 {
     /**
      * Retrieve an external iterator.

--- a/tests/DataContainerDecoratorTraitTest.php
+++ b/tests/DataContainerDecoratorTraitTest.php
@@ -6,6 +6,7 @@
 
 namespace Mediact\DataContainer\Tests;
 
+use ArrayIterator;
 use Mediact\DataContainer\DataContainer;
 use Mediact\DataContainer\DataContainerInterface;
 use Mediact\DataContainer\Tests\TestDouble\DataContainerImplementationDouble;
@@ -260,6 +261,26 @@ class DataContainerDecoratorTraitTest extends TestCase
 
         $double = new DataContainerImplementationDouble($storage);
         $double->move($pattern, $destination);
+    }
+
+    /**
+     * @return void
+     *
+     * @covers ::getIterator
+     */
+    public function testGetIterator()
+    {
+        $data     = ['some_data'];
+        $iterator = new ArrayIterator($data);
+        $storage  = $this->createMock(DataContainerInterface::class);
+
+        $storage
+            ->expects(self::once())
+            ->method('getIterator')
+            ->willReturn($iterator);
+
+        $double = new DataContainerImplementationDouble($storage);
+        $this->assertSame($data, iterator_to_array($double));
     }
 
     /**

--- a/tests/DataContainerIteratorAggregateTraitTest.php
+++ b/tests/DataContainerIteratorAggregateTraitTest.php
@@ -6,8 +6,9 @@
 
 namespace Mediact\DataContainer\Tests;
 
+use IteratorAggregate;
 use Mediact\DataContainer\DataContainerInterface;
-use Mediact\DataContainer\Tests\TestDouble\DataContainerImplementationDouble;
+use Mediact\DataContainer\DataContainerIteratorAggregateTrait;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -30,7 +31,34 @@ class DataContainerIteratorAggregateTraitTest extends TestCase
             ->method('all')
             ->willReturn($data);
 
-        $double = new DataContainerImplementationDouble($storage);
+        $double = new class ($storage) implements IteratorAggregate
+        {
+            use DataContainerIteratorAggregateTrait;
+
+            /** @var DataContainerInterface */
+            private $storage;
+
+            /**
+             * Constructor.
+             *
+             * @param DataContainerInterface $storage
+             */
+            public function __construct(DataContainerInterface $storage)
+            {
+                $this->storage = $storage;
+            }
+
+            /**
+             * Get the storage.
+             *
+             * @return DataContainerInterface
+             */
+            protected function getStorage(): DataContainerInterface
+            {
+                return $this->storage;
+            }
+        };
+
         $this->assertEquals($data, iterator_to_array($double));
     }
 }

--- a/tests/TestDouble/DataContainerImplementationDouble.php
+++ b/tests/TestDouble/DataContainerImplementationDouble.php
@@ -12,10 +12,9 @@ use Mediact\DataContainer\DataContainerDecoratorTrait;
 use Mediact\DataContainer\DataContainerInterface;
 use Mediact\DataContainer\DataContainerIteratorAggregateTrait;
 
-class DataContainerImplementationDouble implements DataContainerInterface, IteratorAggregate
+class DataContainerImplementationDouble implements DataContainerInterface
 {
     use DataContainerDecoratorTrait;
-    use DataContainerIteratorAggregateTrait;
 
     /**
      * Constructor.

--- a/tests/TestDouble/IterableImplementationDouble.php
+++ b/tests/TestDouble/IterableImplementationDouble.php
@@ -1,0 +1,41 @@
+<?php
+/**
+ * Copyright MediaCT. All rights reserved.
+ * https://www.mediact.nl
+ */
+
+namespace Mediact\DataContainer\Tests\TestDouble;
+
+use IteratorAggregate;
+use Mediact\DataContainer\DataContainer;
+use Mediact\DataContainer\DataContainerDecoratorTrait;
+use Mediact\DataContainer\DataContainerInterface;
+use Mediact\DataContainer\DataContainerIteratorAggregateTrait;
+
+class IterableImplementationDouble implements IteratorAggregate
+{
+    use DataContainerIteratorAggregateTrait;
+
+    /** @var DataContainerInterface */
+    private $storage;
+
+    /**
+     * Constructor.
+     *
+     * @param DataContainerInterface $storage
+     */
+    public function __construct(DataContainerInterface $storage)
+    {
+        $this->storage = $storage;
+    }
+
+    /**
+     * Get the storage.
+     *
+     * @return DataContainerInterface
+     */
+    protected function getStorage(): DataContainerInterface
+    {
+        return $this->storage;
+    }
+}


### PR DESCRIPTION
To make it easier to use the data container with classes that expect iterable the interface now extends IteratorAggregate. The data conatiner implementation already was iterable. The already existing interface IterableDataContainerInterface has been made deprecated.