### PR TITLE
2.8.0 Add an interface and implementation to iterate over containers

### DIFF
--- a/src/DataContainerIterator.php
+++ b/src/DataContainerIterator.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * Copyright MediaCT. All rights reserved.
+ * https://www.mediact.nl
+ */
+
+namespace Mediact\DataContainer;
+
+use ArrayIterator;
+use IteratorIterator;
+
+class DataContainerIterator extends IteratorIterator implements
+    DataContainerIteratorInterface
+{
+    /**
+     * Constructor
+     *
+     * @param DataContainerInterface ...$items
+     */
+    public function __construct(
+        DataContainerInterface ...$items
+    ) {
+        parent::__construct(new ArrayIterator($items));
+    }
+
+    /**
+     * Get the current item.
+     *
+     * @return DataContainerInterface
+     */
+    public function current(): DataContainerInterface
+    {
+        return parent::current();
+    }
+}

--- a/src/DataContainerIteratorInterface.php
+++ b/src/DataContainerIteratorInterface.php
@@ -1,0 +1,19 @@
+<?php
+/**
+ * Copyright MediaCT. All rights reserved.
+ * https://www.mediact.nl
+ */
+
+namespace Mediact\DataContainer;
+
+use Iterator;
+
+interface DataContainerIteratorInterface extends Iterator
+{
+    /**
+     * Get the current item.
+     *
+     * @return DataContainerInterface
+     */
+    public function current(): DataContainerInterface;
+}

--- a/tests/DataContainerIteratorTest.php
+++ b/tests/DataContainerIteratorTest.php
@@ -1,0 +1,54 @@
+<?php
+/**
+ * Copyright MediaCT. All rights reserved.
+ * https://www.mediact.nl
+ */
+
+namespace Mediact\DataContainer\Tests;
+
+use Mediact\DataContainer\DataContainerInterface;
+use PHPUnit\Framework\TestCase;
+use Mediact\DataContainer\DataContainerIterator;
+
+/**
+ * @coversDefaultClass \Mediact\DataContainer\DataContainerIterator
+ */
+class DataContainerIteratorTest extends TestCase
+{
+    /**
+     * @param array $containers
+     *
+     * @return void
+     *
+     * @covers ::__construct
+     * @covers ::current
+     *
+     * @dataProvider dataProvider
+     */
+    public function testCurrent(array $containers): void
+    {
+        $subject = new DataContainerIterator(...$containers);
+        $this->assertSame(
+            $containers,
+            iterator_to_array($subject)
+        );
+    }
+
+    /**
+     * @return array
+     */
+    public function dataProvider(): array
+    {
+        return [
+            [
+                [
+                    $this->createMock(DataContainerInterface::class),
+                    $this->createMock(DataContainerInterface::class),
+                ]
+            ],
+            [
+                []
+            ]
+        ];
+    }
+}


### PR DESCRIPTION
The Iterator interface has been extended to specify the return type of
the current method. Having this interface helps with static analysis and
keeps code clean by not having to add type hints. A basic implementation
based on IteratorIterator has been add.