### PR TITLE
2.9.0 Implement replacer that uses the pattern replacer trait

### DIFF
--- a/src/PatternReplacer.php
+++ b/src/PatternReplacer.php
@@ -1,0 +1,48 @@
+<?php
+/**
+ * Copyright MediaCT. All rights reserved.
+ * https://www.mediact.nl
+ */
+
+namespace Mediact\DataContainer;
+
+class PatternReplacer implements PatternReplacerInterface
+{
+    use ReplaceByPatternTrait;
+
+    /** @var string */
+    private $separator;
+
+    /**
+     * Constructor.
+     *
+     * @param string $separator
+     */
+    public function __construct(
+        string $separator = DataContainerInterface::SEPARATOR
+    ) {
+        $this->separator = $separator;
+    }
+
+    /**
+     * Get a replacement path for a matched path.
+     *
+     * @param string $match
+     * @param string $pattern
+     * @param string $replacement
+     *
+     * @return string
+     */
+    public function replace(
+        string $match,
+        string $pattern,
+        string $replacement
+    ): string {
+        return $this->replaceByPattern(
+            $pattern,
+            $match,
+            $replacement,
+            $this->separator
+        );
+    }
+}

--- a/src/PatternReplacerInterface.php
+++ b/src/PatternReplacerInterface.php
@@ -1,0 +1,25 @@
+<?php
+/**
+ * Copyright MediaCT. All rights reserved.
+ * https://www.mediact.nl
+ */
+
+namespace Mediact\DataContainer;
+
+interface PatternReplacerInterface
+{
+    /**
+     * Get a replacement path for a matched path.
+     *
+     * @param string $match
+     * @param string $pattern
+     * @param string $replacement
+     *
+     * @return string
+     */
+    public function replace(
+        string $match,
+        string $pattern,
+        string $replacement
+    ): string;
+}

--- a/tests/PatternReplacerTest.php
+++ b/tests/PatternReplacerTest.php
@@ -1,0 +1,63 @@
+<?php
+/**
+ * Copyright MediaCT. All rights reserved.
+ * https://www.mediact.nl
+ */
+
+namespace Mediact\DataContainer\Tests;
+
+use PHPUnit\Framework\TestCase;
+use Mediact\DataContainer\PatternReplacer;
+
+/**
+ * @coversDefaultClass \Mediact\DataContainer\PatternReplacer
+ */
+class PatternReplacerTest extends TestCase
+{
+    /**
+     * @param string $pattern
+     * @param string $match
+     * @param string $replacement
+     * @param string $separator
+     * @param string $expected
+     *
+     * @return void
+     *
+     * @covers ::replace
+     *
+     * @dataProvider dataProvider
+     */
+    public function testReplace(
+        string $pattern,
+        string $match,
+        string $replacement,
+        string $separator,
+        string $expected
+    ) {
+        $subject = new PatternReplacer($separator);
+
+        $this->assertSame(
+            $expected,
+            $subject->replace($match, $pattern, $replacement)
+        );
+    }
+
+    /**
+     * @return array
+     */
+    public function dataProvider(): array
+    {
+        return [
+            ['foo.*', 'foo.bar', '$0', '.', 'foo.bar'],
+            ['foo.*', 'foo.bar', 'qux.$1', '.', 'qux.bar'],
+            ['foo.ba*', 'foo.bar', 'qux.ba$1', '.', 'qux.bar'],
+            ['foo.ba*', 'foo.bar', 'qux.$1', '.', 'qux.r'],
+            ['foo.ba?', 'foo.bar', 'qux.$1', '.', 'qux.r'],
+            ['foo.ba[rz]', 'foo.bar', 'qux.$1', '.', 'qux.r'],
+            ['foo.ba[!ad]', 'foo.bar', 'qux.$1', '.', 'qux.r'],
+            ['fo*.*', 'foo.bar', '$2.$1.baz', '.', 'bar.o.baz'],
+            ['fo*#*', 'foo#bar', '$2#$1#baz', '#', 'bar#o#baz'],
+            ['fo*/*', 'foo/bar', '$2/$1/baz', '/', 'bar/o/baz'],
+        ];
+    }
+}


### PR DESCRIPTION
It is not desirable for other packages to use the replacer trait.
Therefor it is now wrapped by a replacer which has its own interface.