### PR TITLE
Add support for keys that contain the separator

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -42,13 +42,10 @@
             "/phpcs.xml",
             "/phpstan.neon",
             "/tests",
-            "/example"
+            "/example",
+            "/grumphp.yml",
+            "/pdepend.xml"
         ]
-    },
-    "extra": {
-        "grumphp": {
-            "config-default-path": "vendor/mediact/testing-suite/config/default/grumphp.yml"
-        }
     },
     "config": {
         "sort-packages": true

--- a/example/branching.php
+++ b/example/branching.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright MediaCT. All rights reserved.
  * https://www.mediact.nl
@@ -20,5 +21,5 @@ $container = $factory->create(
 );
 
 foreach ($container->branch('categories.*') as $category) {
-    var_dump($category->get('name'));
+    print_r($category->get('name'));
 }

--- a/grumphp.yml
+++ b/grumphp.yml
@@ -1,0 +1,2 @@
+imports:
+  - resource: 'vendor/mediact/testing-suite/config/default/grumphp.yml'

--- a/pdepend.xml
+++ b/pdepend.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0"?>
+<symfony:container xmlns:symfony="http://symfony.com/schema/dic/services"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns="http://pdepend.org/schema/dic/pdepend"
+    xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+    <config>
+        <cache>
+            <driver>memory</driver>
+        </cache>
+    </config>
+</symfony:container>

--- a/src/DataContainer.php
+++ b/src/DataContainer.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright MediaCT. All rights reserved.
  * https://www.mediact.nl
@@ -24,7 +25,7 @@ class DataContainer implements IterableDataContainerInterface
      *
      * @param array $data
      */
-    public function __construct(iterable $data = [])
+    final public function __construct(iterable $data = [])
     {
         $this->data = $data instanceof Traversable
             ? iterator_to_array($data)
@@ -169,11 +170,11 @@ class DataContainer implements IterableDataContainerInterface
     public function branch(string $pattern): array
     {
         return array_map(
-            function (array $data) : DataContainerInterface {
+            function (array $data): DataContainerInterface {
                 return new static($data);
             },
             array_map(
-                function (string $path) : array {
+                function (string $path): array {
                     return (array) $this->get($path, []);
                 },
                 $this->glob($pattern)
@@ -265,9 +266,10 @@ class DataContainer implements IterableDataContainerInterface
     {
         $current =& $this->data;
 
-        while (count($keys)) {
+        while (!empty($keys)) {
             $key = array_shift($keys);
-            if (!array_key_exists($key, $current)
+            if (
+                !array_key_exists($key, $current)
                 || !is_array($current[$key])
             ) {
                 $current[$key] = [];

--- a/src/DataContainerDecoratorTrait.php
+++ b/src/DataContainerDecoratorTrait.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright MediaCT. All rights reserved.
  * https://www.mediact.nl

--- a/src/DataContainerFactory.php
+++ b/src/DataContainerFactory.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright MediaCT. All rights reserved.
  * https://www.mediact.nl

--- a/src/DataContainerFactoryInterface.php
+++ b/src/DataContainerFactoryInterface.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright MediaCT. All rights reserved.
  * https://www.mediact.nl

--- a/src/DataContainerFilterChain.php
+++ b/src/DataContainerFilterChain.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright MediaCT. All rights reserved.
  * https://www.mediact.nl
@@ -37,7 +38,7 @@ class DataContainerFilterChain implements DataContainerFilterInterface
                 DataContainerFilterInterface $filter
             ) use (
                 $container
-            ) : bool {
+            ): bool {
                 return $carry && $filter($container);
             },
             true

--- a/src/DataContainerFilterInterface.php
+++ b/src/DataContainerFilterInterface.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright MediaCT. All rights reserved.
  * https://www.mediact.nl

--- a/src/DataContainerInterface.php
+++ b/src/DataContainerInterface.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright MediaCT. All rights reserved.
  * https://www.mediact.nl
@@ -16,7 +17,7 @@ interface DataContainerInterface extends IteratorAggregate
     /**
      * The separator used in paths.
      */
-    const SEPARATOR = '.';
+    public const SEPARATOR = '.';
 
     /**
      * Check whether a path exists.

--- a/src/DataContainerInterface.php
+++ b/src/DataContainerInterface.php
@@ -18,6 +18,8 @@ interface DataContainerInterface extends IteratorAggregate
      * The separator used in paths.
      */
     public const SEPARATOR = '.';
+    public const ENCLOSURE = '"';
+    public const ESCAPE    = '\\';
 
     /**
      * Check whether a path exists.

--- a/src/DataContainerIterator.php
+++ b/src/DataContainerIterator.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright MediaCT. All rights reserved.
  * https://www.mediact.nl

--- a/src/DataContainerIteratorAggregateTrait.php
+++ b/src/DataContainerIteratorAggregateTrait.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright MediaCT. All rights reserved.
  * https://www.mediact.nl

--- a/src/DataContainerIteratorInterface.php
+++ b/src/DataContainerIteratorInterface.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright MediaCT. All rights reserved.
  * https://www.mediact.nl

--- a/src/IterableDataContainerInterface.php
+++ b/src/IterableDataContainerInterface.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright MediaCT. All rights reserved.
  * https://www.mediact.nl

--- a/src/KeyQuoterTrait.php
+++ b/src/KeyQuoterTrait.php
@@ -1,0 +1,34 @@
+<?php
+
+/**
+ * Copyright MediaCT. All rights reserved.
+ * https://www.mediact.nl
+ */
+
+namespace Mediact\DataContainer;
+
+trait KeyQuoterTrait
+{
+    /**
+     * Quote a key.
+     *
+     * @param string $key
+     *
+     * @return string
+     */
+    private function quoteKey(string $key): string
+    {
+        return strpos($key, DataContainerInterface::SEPARATOR) !== false
+            ? sprintf(
+                '%s%s%s',
+                DataContainerInterface::ENCLOSURE,
+                str_replace(
+                    DataContainerInterface::ENCLOSURE,
+                    DataContainerInterface::ENCLOSURE . DataContainerInterface::ENCLOSURE,
+                    $key
+                ),
+                DataContainerInterface::ENCLOSURE
+            )
+            : $key;
+    }
+}

--- a/src/PathParserTrait.php
+++ b/src/PathParserTrait.php
@@ -1,0 +1,40 @@
+<?php
+
+/**
+ * Copyright MediaCT. All rights reserved.
+ * https://www.mediact.nl
+ */
+
+namespace Mediact\DataContainer;
+
+trait PathParserTrait
+{
+    /**
+     * Parse a path.
+     *
+     * @param string $path
+     *
+     * @return array
+     */
+    private function parsePath(string $path): array
+    {
+        return array_map(
+            function (string $key) {
+                return ctype_digit($key)
+                    ? intval($key)
+                    : $key;
+            },
+            array_values(
+                array_filter(
+                    str_getcsv(
+                        $path,
+                        DataContainerInterface::SEPARATOR,
+                        DataContainerInterface::ENCLOSURE,
+                        DataContainerInterface::ESCAPE
+                    ),
+                    'strlen'
+                )
+            )
+        );
+    }
+}

--- a/src/PatternReplacer.php
+++ b/src/PatternReplacer.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright MediaCT. All rights reserved.
  * https://www.mediact.nl

--- a/src/PatternReplacerInterface.php
+++ b/src/PatternReplacerInterface.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright MediaCT. All rights reserved.
  * https://www.mediact.nl

--- a/src/ReplaceByPatternTrait.php
+++ b/src/ReplaceByPatternTrait.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright MediaCT. All rights reserved.
  * https://www.mediact.nl

--- a/tests/DataContainerDecoratorTraitTest.php
+++ b/tests/DataContainerDecoratorTraitTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright MediaCT. All rights reserved.
  * https://www.mediact.nl

--- a/tests/DataContainerFactoryTest.php
+++ b/tests/DataContainerFactoryTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright MediaCT. All rights reserved.
  * https://www.mediact.nl

--- a/tests/DataContainerFilterChainTest.php
+++ b/tests/DataContainerFilterChainTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright MediaCT. All rights reserved.
  * https://www.mediact.nl

--- a/tests/DataContainerIteratorAggregateTraitTest.php
+++ b/tests/DataContainerIteratorAggregateTraitTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright MediaCT. All rights reserved.
  * https://www.mediact.nl

--- a/tests/DataContainerIteratorTest.php
+++ b/tests/DataContainerIteratorTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright MediaCT. All rights reserved.
  * https://www.mediact.nl

--- a/tests/DataContainerTest.php
+++ b/tests/DataContainerTest.php
@@ -42,7 +42,6 @@ class DataContainerTest extends TestCase
      * @dataProvider hasDataProvider
      *
      * @covers ::has
-     * @covers ::parsePath
      */
     public function testHas(array $data, string $path, bool $expected)
     {
@@ -105,7 +104,6 @@ class DataContainerTest extends TestCase
      * @dataProvider getDataProvider
      *
      * @covers ::get
-     * @covers ::parsePath
      */
     public function testGet(array $data, string $path, $default, $expected)
     {
@@ -291,7 +289,6 @@ class DataContainerTest extends TestCase
      * @dataProvider removeDataProvider
      *
      * @covers ::remove
-     * @covers ::enclose
      * @covers ::getNodeReference
      */
     public function testRemove(array $data, string $pattern, array $expected)

--- a/tests/DataContainerTest.php
+++ b/tests/DataContainerTest.php
@@ -68,6 +68,11 @@ class DataContainerTest extends TestCase
             ],
             [
                 $this->valuesProvider(),
+                '"baz.a"',
+                true
+            ],
+            [
+                $this->valuesProvider(),
                 'foo.baz.quux.1',
                 true
             ],
@@ -137,6 +142,12 @@ class DataContainerTest extends TestCase
                 'foo.baz.quuux',
                 'some_default',
                 'some_default'
+            ],
+            [
+                $this->valuesProvider(),
+                '"baz.a"',
+                'some_default',
+                'baz_a_value'
             ],
             [
                 [],
@@ -222,12 +233,13 @@ class DataContainerTest extends TestCase
      */
     public function setDataProvider(): array
     {
-        $valuesA = $valuesB = $valuesC = $valuesD = $this->valuesProvider();
+        $valuesA = $valuesB = $valuesC = $valuesD = $valuesE = $this->valuesProvider();
 
         $valuesA['foo']                   = 'new_value';
         $valuesB['foo']['baz']['qux']     = 'new_value';
         $valuesC['foo']['baz']['quux'][1] = 'new_value';
         $valuesD['quux']['quuux']['foo']  = 'new_value';
+        $valuesE['quux']['baz.a']['foo']  = 'new_value';
 
         return [
             [
@@ -256,6 +268,12 @@ class DataContainerTest extends TestCase
             ],
             [
                 $this->valuesProvider(),
+                'quux."baz.a".foo',
+                'new_value',
+                $valuesE
+            ],
+            [
+                $this->valuesProvider(),
                 '',
                 ['foo' => 'bar'],
                 ['foo' => 'bar']
@@ -273,6 +291,7 @@ class DataContainerTest extends TestCase
      * @dataProvider removeDataProvider
      *
      * @covers ::remove
+     * @covers ::enclose
      * @covers ::getNodeReference
      */
     public function testRemove(array $data, string $pattern, array $expected)
@@ -287,12 +306,13 @@ class DataContainerTest extends TestCase
      */
     public function removeDataProvider(): array
     {
-        $valuesA = $valuesB = $valuesC = $valuesD = $this->valuesProvider();
+        $valuesA = $valuesB = $valuesC = $valuesD = $valuesE = $this->valuesProvider();
 
         unset($valuesA['foo']);
         unset($valuesB['foo']['baz']['qux']);
         unset($valuesB['foo']['baz']['quux']);
         unset($valuesC['foo']['baz']['quux'][1]);
+        unset($valuesE['baz.a']);
 
         return [
             [
@@ -314,6 +334,11 @@ class DataContainerTest extends TestCase
                 $this->valuesProvider(),
                 'quux.quuux.foo',
                 $valuesD
+            ],
+            [
+                $this->valuesProvider(),
+                '"baz.a"',
+                $valuesE
             ]
         ];
     }
@@ -354,7 +379,7 @@ class DataContainerTest extends TestCase
             [
                 $this->valuesProvider(),
                 '*',
-                ['foo', 'bar', 'baz', 'qux', 'quux']
+                ['foo', 'bar', 'baz', '"baz.a"', 'qux', 'quux']
             ],
             [
                 $this->valuesProvider(),
@@ -457,6 +482,12 @@ class DataContainerTest extends TestCase
                 'foo.*',
                 'qux.$0',
                 ['foo.bar' => 'qux.foo.bar', 'foo.baz' => 'qux.foo.baz']
+            ],
+            [
+                $this->valuesProvider(),
+                '"b*.a"',
+                'b$1',
+                ['"baz.a"' => 'baz']
             ]
         ];
     }
@@ -750,6 +781,7 @@ class DataContainerTest extends TestCase
                 'qux' => 'bar_qux_value'
             ],
             'baz' => 'baz_value',
+            "baz.a" => "baz_a_value",
             'qux' => null,
             'quux' => [
                 'foo',

--- a/tests/DataContainerTest.php
+++ b/tests/DataContainerTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright MediaCT. All rights reserved.
  * https://www.mediact.nl
@@ -480,7 +481,7 @@ class DataContainerTest extends TestCase
         $this->assertEquals(
             $expected,
             array_map(
-                function (DataContainerInterface $branch) : array {
+                function (DataContainerInterface $branch): array {
                     return $branch->all();
                 },
                 $result

--- a/tests/KeyQuoterTraitTest.php
+++ b/tests/KeyQuoterTraitTest.php
@@ -1,0 +1,73 @@
+<?php
+
+/**
+ * Copyright Alumio. All rights reserved.
+ * https://www.alumio.com
+ */
+
+declare(strict_types=1);
+
+namespace Mediact\DataContainer\Tests;
+
+use Mediact\DataContainer\KeyQuoterTrait;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @coversDefaultClass \Mediact\DataContainer\KeyQuoterTrait
+ */
+class KeyQuoterTraitTest extends TestCase
+{
+    /**
+     * @param string $key
+     * @param string $expected
+     *
+     * @return void
+     *
+     * @covers ::quoteKey
+     *
+     * @dataProvider dataProvider
+     */
+    public function testParsePath(string $key, string $expected)
+    {
+        $subject = new class () {
+            use KeyQuoterTrait;
+
+            /**
+             * @param string $key
+             *
+             * @return string
+             */
+            public function peekQuoteKey(string $key): string
+            {
+                return $this->quoteKey($key);
+            }
+        };
+
+        self::assertSame($expected, $subject->peekQuoteKey($key));
+    }
+
+    /**
+     * @return array
+     */
+    public function dataProvider(): array
+    {
+        return [
+            [
+                '$key'      => 'foo',
+                '$expected' => 'foo'
+            ],
+            [
+                '$key'      => 'foo.bar.baz',
+                '$expected' => '"foo.bar.baz"'
+            ],
+            [
+                '$key'      => 'fo"o',
+                '$expected' => 'fo"o'
+            ],
+            [
+                '$key'      => 'fo"o.bar.baz',
+                '$expected' => '"fo""o.bar.baz"'
+            ]
+        ];
+    }
+}

--- a/tests/PathParserTraitTest.php
+++ b/tests/PathParserTraitTest.php
@@ -1,0 +1,81 @@
+<?php
+
+/**
+ * Copyright Alumio. All rights reserved.
+ * https://www.alumio.com
+ */
+
+declare(strict_types=1);
+
+namespace Mediact\DataContainer\Tests;
+
+use PHPUnit\Framework\TestCase;
+use Mediact\DataContainer\PathParserTrait;
+
+/**
+ * @coversDefaultClass \Mediact\DataContainer\PathParserTrait
+ */
+class PathParserTraitTest extends TestCase
+{
+    /**
+     * @param string $path
+     * @param array  $expected
+     *
+     * @return void
+     *
+     * @covers ::parsePath
+     *
+     * @dataProvider dataProvider
+     */
+    public function testParsePath(string $path, array $expected)
+    {
+        $subject = new class () {
+            use PathParserTrait;
+
+            /**
+             * @param string $path
+             *
+             * @return array
+             */
+            public function peekParsePath(string $path): array
+            {
+                return $this->parsePath($path);
+            }
+        };
+
+        self::assertSame($expected, $subject->peekParsePath($path));
+    }
+
+    /**
+     * @return array
+     */
+    public function dataProvider(): array
+    {
+        return [
+            [
+                '$path'     => '',
+                '$expected' => []
+            ],
+            [
+                '$path'     => 'foo.bar.baz',
+                '$expected' => ['foo', 'bar', 'baz']
+            ],
+            [
+                '$path'     => 'foo.0.baz',
+                '$expected' => ['foo', 0, 'baz']
+            ],
+            [
+                '$path'     => '"fo""o".0."baz.a"',
+                '$expected' => ['fo"o', 0, 'baz.a']
+            ],
+            [
+                '$path'     => '"fo""o".*."baz.a"',
+                '$expected' => ['fo"o', '*', 'baz.a']
+            ],
+            [
+                '$path'     => '"fo""o".."baz.a"..',
+                '$expected' => ['fo"o', 'baz.a']
+            ]
+        ];
+    }
+}

--- a/tests/PatternReplacerTest.php
+++ b/tests/PatternReplacerTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright MediaCT. All rights reserved.
  * https://www.mediact.nl

--- a/tests/ReplaceByPatternTraitTest.php
+++ b/tests/ReplaceByPatternTraitTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright MediaCT. All rights reserved.
  * https://www.mediact.nl

--- a/tests/TestDouble/DataContainerImplementationDouble.php
+++ b/tests/TestDouble/DataContainerImplementationDouble.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright MediaCT. All rights reserved.
  * https://www.mediact.nl

--- a/tests/TestDouble/IterableImplementationDouble.php
+++ b/tests/TestDouble/IterableImplementationDouble.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright MediaCT. All rights reserved.
  * https://www.mediact.nl


### PR DESCRIPTION
Add support for keys that contain the separator
    
The container now uses str_getcsv instead of explode to split paths andpatterns. This enables to use double quotes when a key contains the separator. This way of enclosing is equal to JMESPath.
