### PR TITLE
Keep leading zeros when parsing a path

### DIFF
--- a/src/PathParserTrait.php
+++ b/src/PathParserTrait.php
@@ -20,7 +20,7 @@ trait PathParserTrait
     {
         return array_map(
             function (string $key) {
-                return ctype_digit($key)
+                return ctype_digit($key) && (strlen($key) === 1 || substr($key, 0, 1) !== "0")
                     ? intval($key)
                     : $key;
             },

--- a/tests/PathParserTraitTest.php
+++ b/tests/PathParserTraitTest.php
@@ -75,7 +75,35 @@ class PathParserTraitTest extends TestCase
             [
                 '$path'     => '"fo""o".."baz.a"..',
                 '$expected' => ['fo"o', 'baz.a']
-            ]
+            ],
+            [
+                '$path'     => 'foo.000',
+                '$expected' => ['foo', '000'],
+            ],
+            [
+                '$path'     => 'foo.0001',
+                '$expected' => ['foo', '0001'],
+            ],
+            [
+                '$path'     => 'foo.0001.bar',
+                '$expected' => ['foo', '0001', 'bar'],
+            ],
+            [
+                '$path'     => 'foo.0',
+                '$expected' => ['foo', 0],
+            ],
+            [
+                '$path'     => 'foo.0.bar',
+                '$expected' => ['foo', 0, 'bar'],
+            ],
+            [
+                '$path'     => 'foo.1000',
+                '$expected' => ['foo', 1000],
+            ],
+            [
+                '$path'     => 'foo.1001',
+                '$expected' => ['foo', 1001],
+            ],
         ];
     }
 }


### PR DESCRIPTION
Allow keys to keep leading zeros when parsing a path. Paths like
"foo.000.bar" were turned into ["foo", 0, "bar"] resulting in a
different structure after setting values in the data container.

The key is now only converted into a string if the value is numeric,
and has no leading zero.